### PR TITLE
Cancel events instead of destroy

### DIFF
--- a/app/controllers/api/talent_profiles_controller.rb
+++ b/app/controllers/api/talent_profiles_controller.rb
@@ -12,7 +12,7 @@ module API
 
     def show
       @talent_profile = TalentProfile.find params[:id]
-      @events = @talent_profile.gigs.where(accepted: true).map(&:event)
+      @events = @talent_profile.gigs.joins(:event).select('gigs.id, events.id, events.name, events.description, events.start').where('gigs.accepted = true and events.cancelled is null')
       @gig_count = @talent_profile.gigs.count
 
       render json: { talent: @talent_profile, events: @events, gig_count: @gig_count }

--- a/db/migrate/20201005191002_add_cancelled_to_events.rb
+++ b/db/migrate/20201005191002_add_cancelled_to_events.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Change Event logic to mark cancelled over deleting
+class AddCancelledToEvents < ActiveRecord::Migration[5.2]
+  def change
+    add_column :events, :cancelled, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,94 +10,97 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_201_004_020_526) do
+ActiveRecord::Schema.define(version: 2020_10_05_191002) do
+
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'events', force: :cascade do |t|
-    t.integer 'user_id', null: false
-    t.integer 'genre_id', null: false
-    t.integer 'location_id', null: false
-    t.string 'image_url', null: false
-    t.string 'name', null: false
-    t.datetime 'start', null: false
-    t.datetime 'end', null: false
-    t.integer 'max_attendees', null: false
-    t.text 'description', null: false
-    t.boolean 'accepting_talent', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['genre_id'], name: 'index_events_on_genre_id'
-    t.index ['location_id'], name: 'index_events_on_location_id'
-    t.index ['user_id'], name: 'index_events_on_user_id'
+  create_table "events", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "genre_id", null: false
+    t.integer "location_id", null: false
+    t.string "image_url", null: false
+    t.string "name", null: false
+    t.datetime "start", null: false
+    t.datetime "end", null: false
+    t.integer "max_attendees", null: false
+    t.text "description", null: false
+    t.boolean "accepting_talent", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "cancelled"
+    t.index ["genre_id"], name: "index_events_on_genre_id"
+    t.index ["location_id"], name: "index_events_on_location_id"
+    t.index ["user_id"], name: "index_events_on_user_id"
   end
 
-  create_table 'genres', force: :cascade do |t|
-    t.string 'name', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "genres", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'gigs', force: :cascade do |t|
-    t.integer 'talent_profile_id', null: false
-    t.integer 'event_id', null: false
-    t.text 'description'
-    t.boolean 'accepted'
-    t.boolean 'rejected'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['event_id'], name: 'index_gigs_on_event_id'
-    t.index ['talent_profile_id'], name: 'index_gigs_on_talent_profile_id'
+  create_table "gigs", force: :cascade do |t|
+    t.integer "talent_profile_id", null: false
+    t.integer "event_id", null: false
+    t.text "description"
+    t.boolean "accepted"
+    t.boolean "rejected"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_gigs_on_event_id"
+    t.index ["talent_profile_id"], name: "index_gigs_on_talent_profile_id"
   end
 
-  create_table 'locations', force: :cascade do |t|
-    t.string 'name', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "locations", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'messages', force: :cascade do |t|
-    t.integer 'sender_id', null: false
-    t.integer 'recipient_id', null: false
-    t.text 'content', null: false
-    t.boolean 'read_by_recipient', default: false, null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['recipient_id'], name: 'index_messages_on_recipient_id'
-    t.index ['sender_id'], name: 'index_messages_on_sender_id'
+  create_table "messages", force: :cascade do |t|
+    t.integer "sender_id", null: false
+    t.integer "recipient_id", null: false
+    t.text "content", null: false
+    t.boolean "read_by_recipient", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["recipient_id"], name: "index_messages_on_recipient_id"
+    t.index ["sender_id"], name: "index_messages_on_sender_id"
   end
 
-  create_table 'registrations', force: :cascade do |t|
-    t.integer 'user_id', null: false
-    t.integer 'event_id', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['event_id'], name: 'index_registrations_on_event_id'
-    t.index ['user_id'], name: 'index_registrations_on_user_id'
+  create_table "registrations", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "event_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_registrations_on_event_id"
+    t.index ["user_id"], name: "index_registrations_on_user_id"
   end
 
-  create_table 'talent_profiles', force: :cascade do |t|
-    t.integer 'user_id', null: false
-    t.integer 'genre_id', null: false
-    t.integer 'location_id', null: false
-    t.string 'image_url', null: false
-    t.text 'description', null: false
-    t.string 'personal_link', null: false
-    t.boolean 'open_for_booking', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.string 'name'
-    t.index ['genre_id'], name: 'index_talent_profiles_on_genre_id'
-    t.index ['location_id'], name: 'index_talent_profiles_on_location_id'
-    t.index ['user_id'], name: 'index_talent_profiles_on_user_id'
+  create_table "talent_profiles", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "genre_id", null: false
+    t.integer "location_id", null: false
+    t.string "image_url", null: false
+    t.text "description", null: false
+    t.string "personal_link", null: false
+    t.boolean "open_for_booking", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "name"
+    t.index ["genre_id"], name: "index_talent_profiles_on_genre_id"
+    t.index ["location_id"], name: "index_talent_profiles_on_location_id"
+    t.index ["user_id"], name: "index_talent_profiles_on_user_id"
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'email', null: false
-    t.string 'name', null: false
-    t.integer 'location_id', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['location_id'], name: 'index_users_on_location_id'
+  create_table "users", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "name", null: false
+    t.integer "location_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["location_id"], name: "index_users_on_location_id"
   end
+
 end


### PR DESCRIPTION
Update events controller to handle cancelling over destroying events, modify db accordingly with cancelled field in events table via migration, regenerate schema/seeds, talent_profiles/:id shows only non-cancelled events